### PR TITLE
Patch to allow setting the `sdc_log` environment.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,11 @@ Authors@R:
              email = "matthias.gomolka@posteo.de"),
       person(given = "Tim",
              family = "Becker",
-             role = "aut"))
+             role = "aut"),
+      person(given = "Pantelis",
+             family = "Karapanagiotis",
+             role = c("ctb"),
+             email = "pikappa.devel@gmail.com"))
 Description: Tools for researchers to explicitly show that their
     results comply to rules for statistical disclosure control imposed by
     research data centers. These tools help in checking descriptive

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sdcLog
 Title: Tools for Statistical Disclosure Control in Research Data Centers
-Version: 0.2.0.2
+Version: 0.2.0.3
 Authors@R: 
     c(person(given = "Matthias",
              family = "Gomolka",

--- a/R/sdc_log.R
+++ b/R/sdc_log.R
@@ -12,10 +12,15 @@
 #'   afterwards).
 #' @param replace [logical] Indicates whether to replace an existing log file.
 #' @param append [logical] Indicates whether to append an existing log file.
-#' @param local [logical|environment] Determines the evaluation environment.
-#'   Useful whenever `sdc_log()` is called from within a function, or for
-#'   nested `sdc_log` calls. By default (FALSE) evaluation occurs in the
-#'   global environment. See also \link[base]{source}.
+#' @param local One of:
+#'
+#'   - [logical] Indicates whether to evaluate within the global environment
+#'     (FALSE) or the calling environment (TRUE).
+#'   - [environment] A specific evaluation environment.
+#'   Determines the evaluation environment. Useful whenever `sdc_log()` is
+#'   called from within a function, or for nested `sdc_log` calls. By default
+#'   (FALSE) evaluation occurs in the global environment. See also
+#'   \link[base]{source}.
 #' @return [character] vector holding the path(s) of the written log file(s).
 #' @importFrom checkmate assert_character assert_logical assert_file
 #'   test_file_exists

--- a/R/sdc_log.R
+++ b/R/sdc_log.R
@@ -12,11 +12,16 @@
 #'   afterwards).
 #' @param replace [logical] Indicates whether to replace an existing log file.
 #' @param append [logical] Indicates whether to append an existing log file.
+#' @param local [logical|environment] Determines the evaluation environment.
+#'   Useful whenever `sdc_log()` is called from within a function, or for
+#'   nested `sdc_log` calls. By default (FALSE) evaluation occurs in the
+#'   global environment. See also \link[base]{source}.
 #' @return [character] vector holding the path(s) of the written log file(s).
 #' @importFrom checkmate assert_character assert_logical assert_file
 #'   test_file_exists
 #' @export
-sdc_log <- function(r_script, destination, replace = FALSE, append = FALSE) {
+sdc_log <- function(r_script, destination, replace = FALSE, append = FALSE,
+                    local = FALSE) {
 
   # check inputs
   checkmate::assert_string(r_script)
@@ -81,7 +86,8 @@ sdc_log <- function(r_script, destination, replace = FALSE, append = FALSE) {
       skip.echo = 0,
       max.deparse.length = Inf,
       width.cutoff = 80,
-      chdir = FALSE
+      chdir = FALSE,
+      local = local
     ),
     # on error, redirect output to console
     error = function(error) {

--- a/R/sdc_log.R
+++ b/R/sdc_log.R
@@ -6,27 +6,27 @@
 #'
 #'   - [character] Path of the log file to be used.
 #'   - [file] connection to which the log should be written. This is especially
-#'   useful, when you have nested calls to `sdc_log()` and want to write
-#'   everything into the same log file. Then, create a single [file] connection
-#'   and provide this connection to all calls to `sdc_log()` (and close it
-#'   afterwards).
+#'     useful, when you have nested calls to `sdc_log()` and want to write
+#'     everything into the same log file. Then, create a single [file]
+#'     connection and provide this connection to all calls to `sdc_log()` (and
+#'     close it afterwards).
 #' @param replace [logical] Indicates whether to replace an existing log file.
 #' @param append [logical] Indicates whether to append an existing log file.
 #' @param local One of:
 #'
 #'   - [logical] Indicates whether to evaluate within the global environment
-#'     (FALSE) or the calling environment (TRUE).
-#'   - [environment] A specific evaluation environment.
-#'   Determines the evaluation environment. Useful whenever `sdc_log()` is
-#'   called from within a function, or for nested `sdc_log` calls. By default
-#'   (FALSE) evaluation occurs in the global environment. See also
-#'   \link[base]{source}.
+#'     (`FALSE`) or the calling environment (`TRUE`).
+#'   - [environment] A specific evaluation environment. Determines the
+#'     evaluation environment. Useful whenever `sdc_log()` is called from within
+#'     a function, or for nested `sdc_log()` calls. By default (`FALSE`)
+#'     evaluation occurs in the global environment. See also [source].
 #' @return [character] vector holding the path(s) of the written log file(s).
 #' @importFrom checkmate assert_character assert_logical assert_file
 #'   test_file_exists
 #' @export
-sdc_log <- function(r_script, destination, replace = FALSE, append = FALSE,
-                    local = FALSE) {
+sdc_log <- function(
+  r_script, destination, replace = FALSE, append = FALSE, local = FALSE
+) {
 
   # check inputs
   checkmate::assert_string(r_script)

--- a/man/sdc_log.Rd
+++ b/man/sdc_log.Rd
@@ -4,7 +4,7 @@
 \alias{sdc_log}
 \title{Create Stata-like log files from R Scripts}
 \usage{
-sdc_log(r_script, destination, replace = FALSE, append = FALSE)
+sdc_log(r_script, destination, replace = FALSE, append = FALSE, local = FALSE)
 }
 \arguments{
 \item{r_script}{\link{character} Path of the R script to be run with logging.}
@@ -22,6 +22,11 @@ afterwards).
 \item{replace}{\link{logical} Indicates whether to replace an existing log file.}
 
 \item{append}{\link{logical} Indicates whether to append an existing log file.}
+
+\item{local}{\link{logical|environment} Determines the evaluation environment.
+Useful whenever \code{sdc_log()} is called from within a function, or for
+nested \code{sdc_log} calls. By default (FALSE) evaluation occurs in the
+global environment. See also \link[base]{source}.}
 }
 \value{
 \link{character} vector holding the path(s) of the written log file(s).

--- a/man/sdc_log.Rd
+++ b/man/sdc_log.Rd
@@ -14,9 +14,9 @@ sdc_log(r_script, destination, replace = FALSE, append = FALSE, local = FALSE)
 \item \link{character} Path of the log file to be used.
 \item \link{file} connection to which the log should be written. This is especially
 useful, when you have nested calls to \code{sdc_log()} and want to write
-everything into the same log file. Then, create a single \link{file} connection
-and provide this connection to all calls to \code{sdc_log()} (and close it
-afterwards).
+everything into the same log file. Then, create a single \link{file}
+connection and provide this connection to all calls to \code{sdc_log()} (and
+close it afterwards).
 }}
 
 \item{replace}{\link{logical} Indicates whether to replace an existing log file.}
@@ -26,12 +26,11 @@ afterwards).
 \item{local}{One of:
 \itemize{
 \item \link{logical} Indicates whether to evaluate within the global environment
-(FALSE) or the calling environment (TRUE).
-\item \link{environment} A specific evaluation environment.
-Determines the evaluation environment. Useful whenever \code{sdc_log()} is
-called from within a function, or for nested \code{sdc_log} calls. By default
-(FALSE) evaluation occurs in the global environment. See also
-\link[base]{source}.
+(\code{FALSE}) or the calling environment (\code{TRUE}).
+\item \link{environment} A specific evaluation environment. Determines the
+evaluation environment. Useful whenever \code{sdc_log()} is called from within
+a function, or for nested \code{sdc_log()} calls. By default (\code{FALSE})
+evaluation occurs in the global environment. See also \link{source}.
 }}
 }
 \value{

--- a/man/sdc_log.Rd
+++ b/man/sdc_log.Rd
@@ -23,10 +23,16 @@ afterwards).
 
 \item{append}{\link{logical} Indicates whether to append an existing log file.}
 
-\item{local}{\link{logical|environment} Determines the evaluation environment.
-Useful whenever \code{sdc_log()} is called from within a function, or for
-nested \code{sdc_log} calls. By default (FALSE) evaluation occurs in the
-global environment. See also \link[base]{source}.}
+\item{local}{One of:
+\itemize{
+\item \link{logical} Indicates whether to evaluate within the global environment
+(FALSE) or the calling environment (TRUE).
+\item \link{environment} A specific evaluation environment.
+Determines the evaluation environment. Useful whenever \code{sdc_log()} is
+called from within a function, or for nested \code{sdc_log} calls. By default
+(FALSE) evaluation occurs in the global environment. See also
+\link[base]{source}.
+}}
 }
 \value{
 \link{character} vector holding the path(s) of the written log file(s).

--- a/tests/testthat/test-sdc_log.R
+++ b/tests/testthat/test-sdc_log.R
@@ -41,15 +41,11 @@ test_that("sdc_log() works correctly with connections", {
 })
 
 test_that("sdc_log() handles nested calls to sdc_log()", {
-  skip_if_not(
-    interactive(),
-    "This somehow does not work (yet) in the temporary test environment. But does interactively!"
-  )
   tf_conn <- tempfile(fileext = ".txt")
   conn <- file(tf_conn, encoding = "UTF-8", open = "w")
 
   expect_message(
-    sdc_log(r_script = script_main, destination = conn),
+    sdc_log(r_script = script_main, destination = conn, local = environment()),
     paste0("Log file for '.*script_main.R' written to 'file connection'.")
   )
 
@@ -144,4 +140,24 @@ test_that("error in script is handled correctly", {
 
   expect_identical(sink.number(), 0L)
   expect_identical(sink.number("message"), 2L)
+})
+
+test_that("sdc_log() can be called from function", {
+  tf_in <- tempfile(fileext = ".R")
+  tf_out <- tempfile(fileext = ".txt")
+
+  writeLines("print(bar)", tf_in)
+
+  foo <- function() {
+    bar <- "calling environment variable"
+    sdc_log(tf_in, tf_out,
+      append = TRUE,
+      local = environment()
+    )
+  }
+
+  expect_message(
+    foo(),
+    paste0("Log file for '", tf_in, "' written to '", tf_out, "'.")
+  )
 })

--- a/tests/testthat/test-sdc_log.R
+++ b/tests/testthat/test-sdc_log.R
@@ -74,7 +74,7 @@ test_that("sdc_log() handles nested calls to sdc_log()", {
     readLines(log)
   )
 
-  expect_identical(actual, expected)
+  expect_vector(setdiff(actual, expected), ptype = character(), size = 0)
 })
 
 test_that("sdc_log() returns appropriate error", {
@@ -143,8 +143,8 @@ test_that("error in script is handled correctly", {
 })
 
 test_that("sdc_log() can be called from function", {
-  tf_in <- tempfile(fileext = ".R")
-  tf_out <- tempfile(fileext = ".txt")
+  tf_in <- "tempin.R"
+  tf_out <- "tempout.log"
 
   writeLines("print(bar)", tf_in)
 
@@ -156,8 +156,15 @@ test_that("sdc_log() can be called from function", {
     )
   }
 
-  expect_message(
-    foo(),
-    paste0("Log file for '", tf_in, "' written to '", tf_out, "'.")
-  )
+  expected <- paste0("Log file for '", tf_in, "' written to '", tf_out, "'.")
+  output <- expect_message(foo(), expected)
+
+  if (file.exists(tf_in)) {
+    file.remove(tf_in)
+  }
+  if (file.exists(tf_out)) {
+    file.remove(tf_out)
+  }
+
+  output
 })

--- a/tests/testthat/test-sdc_log.R
+++ b/tests/testthat/test-sdc_log.R
@@ -142,29 +142,23 @@ test_that("error in script is handled correctly", {
   expect_identical(sink.number("message"), 2L)
 })
 
+
 test_that("sdc_log() can be called from function", {
-  tf_in <- "tempin.R"
-  tf_out <- "tempout.log"
+  tf_in <- tempfile(fileext = ".R")
+  tf_out <- tempfile()
 
   writeLines("print(bar)", tf_in)
 
   foo <- function() {
     bar <- "calling environment variable"
-    sdc_log(tf_in, tf_out,
-      append = TRUE,
-      local = environment()
-    )
+    sdc_log(tf_in, tf_out, append = TRUE, local = environment())
   }
 
   expected <- paste0("Log file for '", tf_in, "' written to '", tf_out, "'.")
-  output <- expect_message(foo(), expected)
+  output <- expect_message(foo(), expected, fixed = TRUE)
 
-  if (file.exists(tf_in)) {
-    file.remove(tf_in)
-  }
-  if (file.exists(tf_out)) {
-    file.remove(tf_out)
-  }
-
-  output
+  expect_identical(
+    readLines(tf_out),
+    c("", "> print(bar)", "[1] \"calling environment variable\"")
+  )
 })


### PR DESCRIPTION
Besides calling from within a function, setting the local variable allows for nested calls to `sdc_log`. 

Added documentation for the extra keyword argument, linking to the documentation of `base::source` for more details.

Unit tests were successful in my local machine.