### PR TITLE
fix for #79

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,4 +48,4 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# sdcLog 0.4.0
+
+### Bug Fixes
+
+* Fixed https://github.com/matthiasgomolka/sdcLog/issues/79.
+
 # sdcLog 0.3.0
 
 ### Possibly Breaking Changes

--- a/R/print_methods.R
+++ b/R/print_methods.R
@@ -3,8 +3,12 @@
 #' @export
 print.sdc_distinct_ids <- function(x, ...) {
   distinct_ids <- NULL # removes NSE notes in R CMD check
+
+  var_names <- setdiff(names(x), "distinct_ids")
+  x_non_zero <- subset_zero(x, var_names)
+
   # with problems
-  if (nrow(x[distinct_ids < getOption("sdc.n_ids", 5L)]) > 0L) {
+  if (nrow(x_non_zero[distinct_ids < getOption("sdc.n_ids", 5L)]) > 0L) {
     cat(crayon::red("Not enough distinct entities:\n"))
     print(data.table::as.data.table(x))
 
@@ -111,7 +115,11 @@ print.sdc_model <- function(x, ...) {
 
   n_problems <- vapply(
     append(list(distinct_ids = x[["distinct_ids"]]), x[["terms"]]),
-    function(x) nrow(x[distinct_ids < getOption("sdc.n_ids", 5L)]),
+    function(x) {
+      var_names <- setdiff(names(x), "distinct_ids")
+      x_non_zero <- subset_zero(x, var_names)
+      nrow(x_non_zero[distinct_ids < getOption("sdc.n_ids", 5L)])
+    },
     FUN.VALUE = integer(1L)
   )
   no_problems <- sum(n_problems) == 0L

--- a/R/subset_zero.R
+++ b/R/subset_zero.R
@@ -1,0 +1,21 @@
+# Helper function to remove uncritical rows from a data.table
+#
+# This is necessary in the case where a continuous variable was transformed into
+# a dichotomous variable for SDC purposes. Then, is may only contain the values
+# "<zero>" and "<non-zero>". It is uncritical if there are only a few "<zero>"
+# values, since the variable used to be continuous. This function removes these
+# rows from a data.table.
+#
+# This is necessary for preventing wrong disclosure control warnings.
+#
+#' @noRd
+subset_zero <- function(dt, var_names) {
+    if (identical(var_names, character())) return(dt)
+
+    for (var in var_names) {
+        if (isTRUE(attr(dt[[var]], "was_continuous"))) {
+            dt <- subset(dt[get(var) != "<zero>"])
+        }
+    }
+    return(dt)
+}

--- a/R/warn_distinct_ids.R
+++ b/R/warn_distinct_ids.R
@@ -9,7 +9,11 @@ warn_distinct_ids <- function(list) {
 
     problems <- vapply(
         list,
-        function(x) nrow(x[distinct_ids < getOption("sdc.n_ids", 5L)]) > 0L,
+        function(x) {
+            var_names <- setdiff(names(x), "distinct_ids")
+            x_non_zero <- subset_zero(x, var_names)
+            nrow(x_non_zero[distinct_ids < getOption("sdc.n_ids", 5L)]) > 0L
+        },
         FUN.VALUE = logical(1L)
     )
 

--- a/tests/spelling.R
+++ b/tests/spelling.R
@@ -1,5 +1,3 @@
-if (requireNamespace('spelling', quietly = TRUE)) {
-  spelling::spell_check_test(
-      vignettes = TRUE, error = FALSE, skip_on_cran = TRUE
-  )
-}
+if(requireNamespace('spelling', quietly = TRUE))
+  spelling::spell_check_test(vignettes = TRUE, error = FALSE,
+                             skip_on_cran = TRUE)


### PR DESCRIPTION
In order to prevent throwing wrong warnings, we now check if columns were transformed from continuous to dichotomous (`"<zero>"`, `"<non-zero>"`). This is done via the new column attribute `was_continuous`. If this was the case, we remove `"<zero>"` rows from the data.table before checking if there are enough distinct ID's. 

We do this because for continuous variables, it's no problem, if a few ID's have only `0` values for a specific variable. 

We only have a problem if a continous variable is `"<non-zero>"` for few ID's because then the respective variable identifies the respective ID's.