### PR TITLE
Grep on partial error messages

### DIFF
--- a/tests/testthat/test-sdc_descriptives.R
+++ b/tests/testthat/test-sdc_descriptives.R
@@ -220,7 +220,7 @@ test_that("sdc_descriptives() returns appropriate error", {
     sdc_descriptives(sdc_descriptives_DT, "wrong_id", "val_1"),
     paste0(
       "Assertion on 'id_var' failed: Must be a subset of {'id','id_na',",
-      "'sector','year','val_1','val_2'}, but is {'wrong_id'}."
+      "'sector','year','val_1','val_2'}"
     ),
     fixed = TRUE
   )
@@ -228,7 +228,7 @@ test_that("sdc_descriptives() returns appropriate error", {
     sdc_descriptives(sdc_descriptives_DT, "id", "wrong_val"),
     paste0(
       "Assertion on 'val_var' failed: Must be a subset of {'id_na',",
-      "'sector','year','val_1','val_2'}, but is {'wrong_val'}."
+      "'sector','year','val_1','val_2'}"
     ),
     fixed = TRUE
   )
@@ -236,7 +236,7 @@ test_that("sdc_descriptives() returns appropriate error", {
     sdc_descriptives(sdc_descriptives_DT, "id", "val_1", "wrong_by"),
     paste0(
       "Assertion on 'by' failed: Must be a subset of {'id_na','sector','year',",
-      "'val_2'}, but is {'wrong_by'}."
+      "'val_2'}"
     ),
     fixed = TRUE
   )

--- a/tests/testthat/test-sdc_extreme.R
+++ b/tests/testthat/test-sdc_extreme.R
@@ -211,7 +211,7 @@ test_that("sdc_min_max() returns appropriate error", {
     sdc_min_max(extreme_test_dt, "wrong_id", "val_1"),
     paste0(
       "Assertion on 'id_var' failed: Must be a subset of {'id','val_1',",
-      "'val_2','val_3'}, but is {'wrong_id'}."
+      "'val_2','val_3'}"
     ),
     fixed = TRUE
   )
@@ -219,7 +219,7 @@ test_that("sdc_min_max() returns appropriate error", {
     sdc_min_max(extreme_test_dt, "id", "wrong_val"),
     paste0(
       "Assertion on 'val_var' failed: Must be a subset of {'val_1',",
-      "'val_2','val_3'}, but is {'wrong_val'}."
+      "'val_2','val_3'}"
     ),
     fixed = TRUE
   )
@@ -227,7 +227,7 @@ test_that("sdc_min_max() returns appropriate error", {
     sdc_min_max(extreme_test_dt_by, "id", "val_1", "wrong_by"),
     paste0(
       "Assertion on 'by' failed: Must be a subset of {'sector',",
-      "'val_2','val_3','val_4'}, but is {'wrong_by'}."
+      "'val_2','val_3','val_4'}"
     ),
     fixed = TRUE
   )
@@ -260,17 +260,17 @@ test_that("sdc_min_max() returns appropriate error", {
   )
   expect_error(
     sdc_min_max(extreme_test_dt, "id_var", val_var = "val_1"),
-    "Assertion on 'id_var' failed: Must be a subset of {'id','val_1','val_2','val_3'}, but is {'id_var'}.",
+    "Assertion on 'id_var' failed: Must be a subset of {'id','val_1','val_2','val_3'}",
     fixed = TRUE
   )
   expect_error(
     sdc_min_max(extreme_test_dt, "id", val_var = "val_"),
-    "Assertion on 'val_var' failed: Must be a subset of {'val_1','val_2','val_3'}, but is {'val_'}.",
+    "Assertion on 'val_var' failed: Must be a subset of {'val_1','val_2','val_3'}",
     fixed = TRUE
   )
   expect_error(
     sdc_min_max(extreme_test_dt, "id", val_var = "val_1", by = "by_var"),
-    "Assertion on 'by' failed: Must be a subset of {'val_2','val_3'}, but is {'by_var'}.",
+    "Assertion on 'by' failed: Must be a subset of {'val_2','val_3'}",
     fixed = TRUE
   )
 })

--- a/tests/testthat/test-sdc_log.R
+++ b/tests/testthat/test-sdc_log.R
@@ -101,7 +101,7 @@ test_that("sdc_log() returns appropriate error", {
   file.copy(from = script_1, to = tf)
   expect_error(
     sdc_log(r_script = tf, destination = log),
-    "Assertion on 'r_script' failed: File extension must be in {'R'}.",
+    "Assertion on 'r_script' failed: File extension must be in {'R'}",
     fixed = TRUE
   )
 

--- a/tests/testthat/test-sdc_model.R
+++ b/tests/testthat/test-sdc_model.R
@@ -318,7 +318,7 @@ test_that("sdc_model() returns appropriate errors", {
   )
   expect_error(
     sdc_model(sdc_model_DT, model_1, "wrong_id"),
-    "Assertion on 'id_var' failed: Must be a subset of {'id','y','x_1','x_2','x_3','x_4','dummy_1','dummy_2','dummy_3'}, but is {'wrong_id'}.",
+    "Assertion on 'id_var' failed: Must be a subset of {'id','y','x_1','x_2','x_3','x_4','dummy_1','dummy_2','dummy_3'}",
     fixed = TRUE
   )
   expect_error(


### PR DESCRIPTION
I'm the author of the checkmate package, preparing a new release.
Unfortunately, as I was fixing and improving error messages, I broke your package. 

In general, it is good practice to **not** grep on the complete string in unit tests, but instead only match against the relevant  substring to avoid this kind of problems in the future.

It would be great if you could consider this PR, test against the latest version of checkmate (https://github.com/mllg/checkmate), and upload a patched version in the next few weeks.